### PR TITLE
 add `--generate-yaml`

### DIFF
--- a/bin/format-yarn-outdated.js
+++ b/bin/format-yarn-outdated.js
@@ -5,6 +5,7 @@ const fs   = require('fs');
 const meow = require('meow');
 
 const Formatter = require('../lib/Formatter');
+const generateYaml = require('../lib/generateYaml')
 
 const cli = meow(`
   NAME
@@ -19,6 +20,7 @@ const cli = meow(`
     --version, -v    Prints the package version.
     --format, -f     Output format. One of either markdown, json or mackerel can be used. Default: markdown
     --excludes, -e   Path to YAML file which specify package names to exclude
+    --generate-yaml  Generate YAML file which specify changelog uris for the packages
     --changelogs, -c Path to YAML file which specify changelog uris for the packages
 
   EXAMPLES
@@ -38,6 +40,11 @@ const cli = meow(`
 
 const selectFormat = val => ['markdown', 'json', 'mackerel'].includes(val) ? val : 'markdown';
 const loadYAML = val => val ? yaml.safeLoad(fs.readFileSync(val, 'utf8')) : null;
+
+if (cli.flags.generateYaml) {
+  generateYaml();
+  process.exit(0);
+}
 
 // observe stdin
 let stdin = '';

--- a/lib/generateYaml.js
+++ b/lib/generateYaml.js
@@ -1,0 +1,38 @@
+const fs   = require('fs');
+const path = require('path');
+
+const urlize = (repo) => {
+  if (typeof repo !== 'string') return null;
+  // ex: facebook/react
+  let regexp = new RegExp('^[a-zA-Z0-9-]+\/[a-zA-Z0-9-]+$');
+  if (regexp.test(repo)) return 'https://github.com/' + repo;
+  repo = repo.replace(/\.git$/, '');
+  // ex: git+ssh://git@github.com/mikaelbr/node-notifier.git
+  regexp = new RegExp('.+?:\/\/git@');
+  if (regexp.test(repo)) return repo.replace(regexp, 'https://');
+  // ex: git@github.com:xjamundx/eslint-plugin-promise.git
+  regexp = new RegExp('^git@');
+  if (regexp.test(repo)) return repo.replace(regexp, 'https://');
+  // ex: git+https://github.com/ded/bowser.git
+  regexp = new RegExp('^git(?:\\+https?)?');
+  if (regexp.test(repo)) return repo.replace(regexp, 'https');
+  return repo.replace(/^http:/, 'https:');
+};
+
+module.exports = () => {
+  const rootPackageJson = JSON.parse(fs.readFileSync(path.resolve('./package.json')));
+  const dependencies = Object.assign(rootPackageJson.dependencies, rootPackageJson.devDependencies);
+  const nodeModulelDirs = fs.readdirSync(path.resolve('./node_modules'));
+  nodeModulelDirs
+    .filter((name) => !!dependencies[name])
+    .forEach((moduleName) => {
+      const dirPath = path.resolve(path.join('./node_modules', moduleName));
+      const packageJson = JSON.parse(fs.readFileSync(path.join(dirPath, 'package.json')));
+      let repositoryURL = typeof packageJson.repository === 'object' ? packageJson.repository.url : packageJson.repository;
+      repositoryURL = urlize(repositoryURL);
+      if (!repositoryURL) return;
+      const changelogFileName = fs.readdirSync(dirPath).find((name) => name.match(/^CHANGE/i));
+      if (!changelogFileName) return;
+      console.log(`${moduleName}: ${repositoryURL}/blob/master/${changelogFileName}`) // eslint-disable-line
+    });
+};


### PR DESCRIPTION
Preparing `changelogs.yaml` is too hard.

This will support `changelog.yaml`. If there is CHNAGELOG file on
`node_modules/MODULE_NAME`'s 1st level, it outputs its CHANGELOG URL.

## Sample Output

```
babel-plugin-espower: https://github.com/power-assert-js/babel-plugin-espower/blob/master/CHANGELOG.md
babel-preset-env: https://github.com/babel/babel-preset-env/blob/master/CHANGELOG.md
bluebird: https://github.com/petkaantonov/bluebird/blob/master/changelog.md
bootstrap: https://github.com/twbs/bootstrap/blob/master/CHANGELOG.md
bootstrap-sass: https://github.com/twbs/bootstrap-sass/blob/master/CHANGELOG.md
bowser: https://github.com/ded/bowser/blob/master/CHANGELOG.md
browser-sync: https://github.com/Browsersync/browser-sync/blob/master/CHANGELOG.md
browserify: https://github.com/substack/node-browserify/blob/master/changelog.markdown
debug: https://github.com/visionmedia/debug/blob/master/CHANGELOG.md
es5-shim: https://github.com/es-shims/es5-shim/blob/master/CHANGES
es6-shim: https://github.com/paulmillr/es6-shim/blob/master/CHANGELOG.md
eslint: https://github.com/eslint/eslint/blob/master/CHANGELOG.md
eslint-config-standard: https://github.com/feross/eslint-config-standard/blob/master/CHANGELOG.md
eslint-plugin-import: https://github.com/benmosher/eslint-plugin-import/blob/master/CHANGELOG.md
eslint-plugin-promise: https://github.com:xjamundx/eslint-plugin-promise/blob/master/CHANGELOG.md
eslint-plugin-react: https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md
eslint-plugin-standard: https://github.com/xjamundx/eslint-plugin-standard/blob/master/CHANGELOG.md
eventemitter2: https://github.com/hij1nx/EventEmitter2/blob/master/CHANGELOG.md
flux: https://github.com/facebook/flux/blob/master/CHANGELOG.md
glob: https://github.com/isaacs/node-glob/blob/master/changelog.md
gulp: https://github.com/gulpjs/gulp/blob/master/CHANGELOG.md
gulp-clean-css: https://github.com/scniro/gulp-clean-css/blob/master/CHANGELOG.md
gulp-sass: https://github.com/dlmanning/gulp-sass/blob/master/CHANGELOG.md
gulp-uglify: https://github.com/terinjokes/gulp-uglify/blob/master/CHANGELOG.md
i18n-js: https://github.com/fnando/i18n-js/blob/master/CHANGELOG.md
js-yaml: https://github.com/nodeca/js-yaml/blob/master/CHANGELOG.md
jsdom: https://github.com/tmpvar/jsdom/blob/master/Changelog.md
mocha: https://github.com/mochajs/mocha/blob/master/CHANGELOG.md
moment: https://github.com/moment/moment/blob/master/CHANGELOG.md
nock: https://github.com/node-nock/nock/blob/master/CHANGELOG.md
node-notifier: https://github.com/mikaelbr/node-notifier/blob/master/CHANGELOG.md
power-assert: https://github.com/power-assert-js/power-assert/blob/master/CHANGELOG.md
raven-js: https://github.com/getsentry/raven-js/blob/master/CHANGELOG.md
react-bootstrap: https://github.com/react-bootstrap/react-bootstrap/blob/master/CHANGELOG.md
react-helmet: https://github.com/nfl/react-helmet/blob/master/CHANGELOG.md
react-overflow-tooltip: https://github.com/uiureo/react-overflow-tooltip/blob/master/CHANGELOG.md
react-textarea-autosize: https://github.com/andreypopp/react-textarea-autosize/blob/master/CHANGELOG.md
responsive-toolkit: https://github.com/maciej-gurban/responsive-bootstrap-toolkit/blob/master/CHANGELOG.md
sinon: https://github.com/cjohansen/Sinon.JS/blob/master/Changelog.txt
superagent-bluebird-promise: https://github.com/KyleAMathews/superagent-bluebird-promise/blob/master/CHANGELOG.MD
truncate: https://github.com:FGRibreau/node-truncate/blob/master/CHANGELOG.md
yargs: https://github.com/yargs/yargs/blob/master/CHANGELOG.md
```