### PR TITLE
Support npm outdated --json

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ EXAMPLES
   $ yarn outdated --json | $(yarn bin)/format-yarn-outdated --excludes /path/to/excludes.yml --changelogs /path/to/changelogs.yml
   $ yarn outdated --json | $(yarn bin)/format-yarn-outdated --format json | jq '.minor[],.patch[] | .[0]' | xargs -I{} yarn upgrade {}
   $ yarn outdated --json | $(yarn bin)/format-yarn-outdated --format mackerel | mkr throw --service ServiceMetricName
+
+NPM SUPPORT
+  To detecting dependencies or devDependencies, --long option is required.
+  $ npm outdated --json --long | $(yarn bin)/format-yarn-outdated
+
+  URL will not shown.
+  CHANGELOG URL will not shown unless you set --changelogs option.
 ```
 
 ## Examples

--- a/bin/format-yarn-outdated.js
+++ b/bin/format-yarn-outdated.js
@@ -27,6 +27,13 @@ const cli = meow(`
     $ yarn outdated --json | $(yarn bin)/format-yarn-outdated --excludes /path/to/excludes.yml --changelogs /path/to/changelogs.yml
     $ yarn outdated --json | $(yarn bin)/format-yarn-outdated --format json | jq '.minor[],.patch[] | .[0]' | xargs -I{} yarn upgrade {}
     $ yarn outdated --json | $(yarn bin)/format-yarn-outdated --format mackerel | mkr throw --service ServiceMetricName
+
+  NPM SUPPORT
+    To detecting dependencies or devDependencies, --long option is required.
+    $ npm outdated --json --long | $(yarn bin)/format-yarn-outdated
+
+    URL will not shown.
+    CHANGELOG URL will not shown unless you set --changelogs option.
 `, {
   alias: {
     h: 'help',

--- a/lib/Formatter.js
+++ b/lib/Formatter.js
@@ -25,30 +25,38 @@ class Formatter {
     return result;
   }
 
-  extractOutdatedPackages(json) {
+  extractOutdatedPackages (json) {
     const packages = (json.data && json.data.body) ? json.data.body : this.extractPackagesFromNpmOutdatedJSON(json);
-      return packages
-        .filter((p) => !p.slice(1, 3).includes('exotic'))
-        .filter((p) => !this.excludes.includes(p[0]))
-        .map((p) => {
-          p.push(this.changelogs[p[0]] || '');
-          return p;
-        });
+    return packages
+      .filter((p) => !p.slice(1, 3).includes('exotic'))
+      .filter((p) => !this.excludes.includes(p[0]))
+      .map((p) => {
+        p.push(this.changelogs[p[0]] || '');
+        return p;
+      });
   }
 
   /* convert { packageName: { current, wanted, latest, type }} to [ packageName, current, wanted, latest, type, url(null) ] */
-  extractPackagesFromNpmOutdatedJSON(json) {
+  extractPackagesFromNpmOutdatedJSON (json) {
     return Object.keys(json).map(packageName => {
       const info = json[packageName];
       return [
         packageName,
-        info.current,
-        info.wanted,
-        info.latest,
+        this.npmVersionToYarnVersion(info.current),
+        this.npmVersionToYarnVersion(info.wanted),
+        this.npmVersionToYarnVersion(info.latest),
         info.type,
-        null
+        null,
       ];
     });
+  }
+
+  /* convert "git" to "exotic" */
+  npmVersionToYarnVersion (version) {
+    if (version === 'git') {
+      return 'exotic';
+    }
+    return version;
   }
 
   sortPackages (packages) {

--- a/lib/Formatter.js
+++ b/lib/Formatter.js
@@ -25,14 +25,30 @@ class Formatter {
     return result;
   }
 
-  extractOutdatedPackages (json) {
-    return json.data.body
-      .filter((p) => ! p.slice(1, 3).includes('exotic'))
-      .filter((p) => ! this.excludes.includes(p[0]))
-      .map((p) => {
-        p.push(this.changelogs[p[0]] || '');
-        return p;
-      });
+  extractOutdatedPackages(json) {
+    const packages = (json.data && json.data.body) ? json.data.body : this.extractPackagesFromNpmOutdatedJSON(json);
+      return packages
+        .filter((p) => !p.slice(1, 3).includes('exotic'))
+        .filter((p) => !this.excludes.includes(p[0]))
+        .map((p) => {
+          p.push(this.changelogs[p[0]] || '');
+          return p;
+        });
+  }
+
+  /* convert { packageName: { current, wanted, latest, type }} to [ packageName, current, wanted, latest, type, url(null) ] */
+  extractPackagesFromNpmOutdatedJSON(json) {
+    return Object.keys(json).map(packageName => {
+      const info = json[packageName];
+      return [
+        packageName,
+        info.current,
+        info.wanted,
+        info.latest,
+        info.type,
+        null
+      ];
+    });
   }
 
   sortPackages (packages) {

--- a/test/data/expected-without-url.md
+++ b/test/data/expected-without-url.md
@@ -1,0 +1,14 @@
+# Major
+| Package | Current | Wanted | Latest | Package Type | URL | CHANGELOG |
+|---|---|---|---|---|---|---|
+| major-up-package | 1.0.0 | 2.0.0 | 2.0.0 | dependencies |  |  |
+
+# Minor
+| Package | Current | Wanted | Latest | Package Type | URL | CHANGELOG |
+|---|---|---|---|---|---|---|
+| minor-up-package | 1.0.0 | 1.1.0 | 1.1.0 | dependencies |  |  |
+
+# Patch
+| Package | Current | Wanted | Latest | Package Type | URL | CHANGELOG |
+|---|---|---|---|---|---|---|
+| patch-up-package | 1.0.0 | 1.0.1 | 1.0.1 | dependencies |  |  |

--- a/test/fixture/outdated.npm.json
+++ b/test/fixture/outdated.npm.json
@@ -1,0 +1,30 @@
+{
+  "exotic-package": {
+    "current": "1.0.0",
+    "wanted": "exotic",
+    "latest": "exotic",
+    "location": "node_modules/exotic",
+    "type": "dependencies"
+  },
+  "major-up-package": {
+    "current": "1.0.0",
+    "wanted": "2.0.0",
+    "latest": "2.0.0",
+    "location": "node_modules/major",
+    "type": "dependencies"
+  },
+  "minor-up-package": {
+    "current": "1.0.0",
+    "wanted": "1.1.0",
+    "latest": "1.1.0",
+    "location": "node_modules/minor",
+    "type": "dependencies"
+  },
+  "patch-up-package": {
+    "current": "1.0.0",
+    "wanted": "1.0.1",
+    "latest": "1.0.1",
+    "location": "node_modules/patch",
+    "type": "dependencies"
+  }
+}

--- a/test/fixture/outdated.npm.json
+++ b/test/fixture/outdated.npm.json
@@ -1,8 +1,8 @@
 {
   "exotic-package": {
     "current": "1.0.0",
-    "wanted": "exotic",
-    "latest": "exotic",
+    "wanted": "git",
+    "latest": "git",
     "location": "node_modules/exotic",
     "type": "dependencies"
   },

--- a/test/format-yarn-outdated.js
+++ b/test/format-yarn-outdated.js
@@ -61,3 +61,21 @@ test('format-yarn-outdated with yarn@1.2.1', t => {
   formatDiffRegex(['--format', 'mackerel'], /outdated_npm_packages\.(major|minor|patch)\t1\t\d+/);
   formatDiffRegex(['-f', 'mackerel'], /outdated_npm_packages\.(major|minor|patch)\t1\t\d+/);
 });
+
+test('format-yarn-outdated with npm', t => {
+  const input = readFile(cd('./fixture/outdated.npm.json'));
+  const formatDiff = (args, expected) => {
+    const result = execa.sync(cd('../bin/format-yarn-outdated.js'), args, { input });
+    t.is(result.stdout, expected);
+  };
+
+  const formatDiffRegex = (args, expectedRegex) => {
+    const result = execa.sync(cd('../bin/format-yarn-outdated.js'), args, { input });
+    t.regex(result.stdout, expectedRegex);
+  };
+
+  formatDiff([], readFile(cd('./data/expected-without-url.md')));
+  formatDiffRegex(['--format', 'mackerel'], /outdated_npm_packages\.(major|minor|patch)\t1\t\d+/);
+  formatDiffRegex(['-f', 'mackerel'], /outdated_npm_packages\.(major|minor|patch)\t1\t\d+/);
+
+});


### PR DESCRIPTION
I added a feature to parse output of `npm outdated --json`. We are currently using npm and we want to post outdated counts to mackerel.