### PR TITLE
Drop Node 6 and 8 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [6, 8, 10, 12, 14]
+        node: [10, 12, 14]
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
closes #55 

Node 6 and 8 is no longer supported.
https://github.com/nodejs/Release#end-of-life-releases